### PR TITLE
add option in issues to get RDD metrics fro DDR and TTR

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ For the RDD generation:
 
     pds-issues  --github-repos validate --issue_state closed --format rst --start-time 2020-10-26T00:00:00Z
     
+For RD metrics:
+
+    pds-issues --issue_state closed --format metrics --start-time 2020-10-26T00:00:00+00:00 --end-time 2021-04-19T00:00:00+00:00
+
+    
 Generates `pdsen_issues.rst`
 
 # Development

--- a/pds_github_util/issues/RstRddReport.py
+++ b/pds_github_util/issues/RstRddReport.py
@@ -130,9 +130,11 @@ class MetricsRddReport(RddReport):
                 else:
                     self.bugs_open_closed[issue.state] = 1
 
-                self._logger.info("%s#%i %s %s %s", repo, issue.number, issue.title, severity, issue.state)
+
                 if issue.state == 'open' and severity in {'s.critical', 's.high'}:
-                    self.high_and_critical_open_bugs.append("%s#%i %s %s\n" % repo, issue.number, issue.title, severity)
+                  :q
+                  self._logger.info("%s#%i %s %s %s", repo, issue.number, issue.title, severity, issue.state)
+                    self.high_and_critical_open_bugs += "%s#%i %s %s\n" % (repo, issue.number, issue.title, severity)
 
 
                 # get count

--- a/pds_github_util/issues/RstRddReport.py
+++ b/pds_github_util/issues/RstRddReport.py
@@ -1,12 +1,12 @@
 from pds_github_util.utils import GithubConnection, RstClothReferenceable
+from datetime import datetime
 
 import logging
-import os
-import sys
 
-from .utils import get_issue_type, get_issue_priority, ignore_issue, get_issues_groupby_type
 
-class RstRddReport:
+from pds_github_util.issues.utils import get_issue_priority, ignore_issue
+
+class RddReport:
 
     ISSUE_TYPES = ['bug', 'enhancement', 'requirement', 'theme']
     IGNORED_LABELS = {'wontfix', 'duplicate', 'invalid', 'I&T', 'untestable'}
@@ -14,8 +14,8 @@ class RstRddReport:
 
     def __init__(self,
                  org,
-                 title='Release Description Document (build 11.1), software changes',
                  start_time=None,
+                 end_time=None,
                  token=None):
 
         # Quiet github3 logging
@@ -28,30 +28,147 @@ class RstRddReport:
         self._org = org
         self._gh = GithubConnection.getConnection(token=token)
         self._start_time = start_time
-        self._rst_doc = RstClothReferenceable()
-        self._rst_doc.title(title)
+        self._end_time = end_time
 
     def available_repos(self):
         for _repo in self._gh.repositories_by(self._org):
             if _repo.name not in RstRddReport.IGNORED_REPOS:
                 yield _repo
 
-    def add_repo(self, repo):
-        issues_map = self._get_issues_groupby_type(repo, state='closed', start_time=self._start_time)
-        issue_count = sum([len(issues) for _, issues in issues_map.items()])
-        if issue_count > 0:
-            self._write_repo_section(repo.name, issues_map)
-
-    def _get_issues_groupby_type(self, repo, state='closed', start_time=None):
+    def _get_issues_groupby_type(self, repo, state='closed'):
         issues = {}
         for t in RstRddReport.ISSUE_TYPES:
             self._logger.info(f'++++++++{t}')
             issues[t] = []
-            for issue in repo.issues(state=state, labels=t, direction='asc', since=start_time):
+            for issue in repo.issues(state=state,
+                                     labels=t,
+                                     direction='asc',
+                                     since=self._start_time,
+                                     until=self._end_time):
                 if not ignore_issue(issue.labels(), ignore_labels=RstRddReport.IGNORED_LABELS):
                     issues[t].append(issue)
 
         return issues
+
+
+
+
+
+class MetricsRddReport(RddReport):
+
+    def __init__(self,
+                 org,
+                 start_time=None,
+                 end_time=None,
+                 token=None):
+        super().__init__(org, start_time, end_time, token)
+        self.issues_type_counts = {}
+        for t in self.ISSUE_TYPES:
+            self.issues_type_counts[t] = 0
+
+        self.issues_type_five_biggest = {}
+        for t in self.ISSUE_TYPES:
+            self.issues_type_five_biggest[t] = []
+
+        self.bugs_open_closed = {}
+        self.bugs_severity = {};
+
+        self.high_and_critical_open_bugs = ""
+
+
+    def create(self, repos):
+        for _repo in self.available_repos():
+            if not repos or _repo.name in repos:
+                self.add_repo(_repo)
+
+        print('Issues types')
+        print(self.issues_type_counts)
+
+        print('Bug states')
+        print(self.bugs_open_closed)
+
+        print('Bug severity')
+        print(self.bugs_severity)
+
+        print('Open high and critical bugs')
+        print(self.high_and_critical_open_bugs)
+
+    def _non_bug_metrics(self, type, repo):
+        for issue in repo.issues(
+                state='closed',
+                labels=type,
+                direction='asc',
+                since=self._start_time
+        ):
+            if not ignore_issue(issue.labels(), ignore_labels=RstRddReport.IGNORED_LABELS) \
+                    and issue.created_at <  datetime.fromisoformat(self._end_time):
+                self.issues_type_counts[type] += 1
+
+    def _bug_metrics(self, repo):
+        for issue in repo.issues(
+                state='all',
+                labels='bug',
+                direction='asc',
+                since=self._start_time
+        ):
+            if not ignore_issue(issue.labels(), ignore_labels=RstRddReport.IGNORED_LABELS) \
+                    and issue.created_at < datetime.fromisoformat(self._end_time):
+                # get severity
+                severity = 's.unknown'
+                for label in issue.labels():
+                    if label.name.startswith('s.'):
+                        severity = label.name
+                        break
+                if severity in self.bugs_severity.keys():
+                    self.bugs_severity[severity] += 1
+                else:
+                    self.bugs_severity[severity] = 1
+
+                # get state
+                if issue.state in self.bugs_open_closed.keys():
+                    self.bugs_open_closed[issue.state] += 1
+                else:
+                    self.bugs_open_closed[issue.state] = 1
+
+                self._logger.info("%s#%i %s %s %s", repo, issue.number, issue.title, severity, issue.state)
+                if issue.state == 'open' and severity in {'s.critical', 's.high'}:
+                    self.high_and_critical_open_bugs.append("%s#%i %s %s\n" % repo, issue.number, issue.title, severity)
+
+
+                # get count
+                if issue.state == 'closed':
+                    self.issues_type_counts['bug'] += 1
+                else:
+                    self._logger.info("this issues is still open %s#%i: %s", repo, issue.number, issue.title)
+
+    def _get_issue_type_count(self, repo):
+        for t in RstRddReport.ISSUE_TYPES:
+            if t == 'bug':
+                self._bug_metrics(repo)
+            else:
+                self._non_bug_metrics(t, repo)
+
+    def add_repo(self, repo):
+        self._logger.info("add repo %s", repo)
+        self._get_issue_type_count(repo)
+
+
+class RstRddReport(RddReport):
+
+    def __init__(self,
+                 org,
+                 title='Release Description Document (build 11.1), software changes',
+                 start_time=None,
+                 token=None):
+
+        super().__init__(org,
+                         start_time,
+                         token)
+
+        self._rst_doc = RstClothReferenceable()
+        self._rst_doc.title(title)
+
+
 
     def _write_repo_section(self, repo, issues_map):
         self._rst_doc.h2(repo)
@@ -73,6 +190,24 @@ class RstRddReport:
         self._rst_doc.table(
             columns,
             data=data)
+
+    def add_repo(self, repo):
+        issues_map = self._get_issues_groupby_type(
+            repo,
+            state='closed',
+            start_time=self._start_time,
+            end_time=self._end_time
+        )
+        issue_count = sum([len(issues) for _, issues in issues_map.items()])
+        if issue_count > 0:
+            self._write_repo_section(repo.name, issues_map)
+
+    def create(self, repos, filename):
+        for _repo in self.available_repos():
+            if not repos or _repo.name in repos:
+                self.add_repo(_repo)
+
+        self.write('pdsen_issues.rst')
 
     def write(self, filename):
         self._logger.info('Create file %s', filename)

--- a/pds_github_util/issues/__init__.py
+++ b/pds_github_util/issues/__init__.py
@@ -1,1 +1,2 @@
 from .RstRddReport import RstRddReport
+from .RstRddReport import MetricsRddReport

--- a/pds_github_util/issues/issues.py
+++ b/pds_github_util/issues/issues.py
@@ -4,14 +4,14 @@ Tool to generate simple markdown issue reports
 """
 import argparse
 import logging
-import os
-import sys
+
 
 from mdutils.mdutils import MdUtils
-from .utils import TOP_PRIORITIES, get_issue_type, get_issue_priority, ignore_issue, get_issues_groupby_type, is_theme
+from pds_github_util.issues.utils import TOP_PRIORITIES, get_issue_priority, get_issues_groupby_type
 
 from pds_github_util.utils import GithubConnection
 from pds_github_util.issues import RstRddReport
+from pds_github_util.issues import MetricsRddReport
 
 DEFAULT_GITHUB_ORG = 'NASA-PDS'
 
@@ -81,7 +81,7 @@ def main():
     parser.add_argument('--end-time',
                         help='End datetime for tickets to find. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.')
     parser.add_argument('--format', default='md',
-                        help='rst or md')
+                        help='rst or md or metrics')
 
     args = parser.parse_args()
 
@@ -102,12 +102,19 @@ def main():
             token=args.token
         )
 
-        for _repo in rst_rdd_report.available_repos():
-            if not args.github_repos or _repo.name in args.github_repos:
-                rst_rdd_report.add_repo(_repo)
+        rst_rdd_report.create(args.github_repos, 'pdsen_issues.rst')
 
-        rst_rdd_report.write('pdsen_issues.rst')
+    elif args.format == 'metrics':
+
+        rdd_metrics = MetricsRddReport(
+            args.github_org,
+            start_time=args.start_time,
+            end_time=args.end_time,
+            token=args.token
+        )
+
+        rdd_metrics.create(args.github_repos)
 
     else:
-        logger.error("unsupported format %s, must be rst or md", args.format)
+        logger.error("unsupported format %s, must be rst or md or metrics", args.format)
 


### PR DESCRIPTION
**Summary***
add option in issues to get RDD metrics fro DDR and TTR, very basic metrics returned in stdout.

To be completed.


**Test Data and/or Report**
Run command:
    pds-issues --issue_state all --format metrics --start-time 2020-10-26T00:00:00+00:00 --end-time 2021-04-19T00:00:00+00:00


**Related Issues**
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
->