### PR TITLE
add a test to ignore issues with empty descriptions so no requirements

### DIFF
--- a/pds_github_util/requirements/requirements.py
+++ b/pds_github_util/requirements/requirements.py
@@ -65,19 +65,20 @@ class Requirements:
         requirements_issue_map = {}
         requirements_tag_map = {}
         for issue in self._repo.issues(state='closed', direction='asc'):
-            body_sections = issue.body.split("**Applicable requirements")
-            if len(body_sections) > 1:
-                impacted_requirements_str = body_sections[1]
-                prog = re.compile("#[0-9]+")
-                requirements = prog.findall(impacted_requirements_str)
-                requirements = [ int(req[1:]) for req in requirements] # remove leading # and convert to int to be consistent with requirement dictionnary
-                for req in requirements:
-                    if req not in requirements_tag_map.keys():
-                        requirements_tag_map[req] = {'issues': set(),  'tags': set()}
-                    issue_date_isoz = issue.closed_at.isoformat().replace('+00:00', 'Z')
-                    earliest_tag_closed_after = self._tags.get_earliest_tag_after(issue_date_isoz)
-                    requirements_tag_map[req]['issues'].add(issue.number)
-                    requirements_tag_map[req]['tags'].add(earliest_tag_closed_after)
+            if issue.body:
+                body_sections = issue.body.split("**Applicable requirements")
+                if len(body_sections) > 1:
+                    impacted_requirements_str = body_sections[1]
+                    prog = re.compile("#[0-9]+")
+                    requirements = prog.findall(impacted_requirements_str)
+                    requirements = [ int(req[1:]) for req in requirements] # remove leading # and convert to int to be consistent with requirement dictionnary
+                    for req in requirements:
+                        if req not in requirements_tag_map.keys():
+                            requirements_tag_map[req] = {'issues': set(),  'tags': set()}
+                        issue_date_isoz = issue.closed_at.isoformat().replace('+00:00', 'Z')
+                        earliest_tag_closed_after = self._tags.get_earliest_tag_after(issue_date_isoz)
+                        requirements_tag_map[req]['issues'].add(issue.number)
+                        requirements_tag_map[req]['tags'].add(earliest_tag_closed_after)
         return requirements_tag_map
 
     def get_requirements(self):


### PR DESCRIPTION
**Summary***
The update avoid the error on empty desciption's body.
I was not able to fully test it though because the python template repo does not have a dev/snapshot tag available.

**Test Data and/or Report**
Test on pds-template-repo-python as shown in action https://github.com/NASA-PDS/pds-template-repo-python/runs/3187425914?check_suite_focus=true#step:4:223

**Related Issues**
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
->

Fiexes #16 