### PR TITLE
Update pds-github-util to emit repository dispatch for build triggering

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -61,6 +61,13 @@ jobs:
                     pypi_username: ${{secrets.PYPI_USERNAME}}
                     pypi_password: ${{secrets.PYPI_PASSWORD}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
+            -
+                name: Trigger github-actions-base build
+                uses: peter-evans/repository-dispatch@v1
+                with:
+                    token: ${{secrets.ADMIN_GITHUB_TOKEN}}
+                    repository: NASA-PDS/github-actions-base
+                    event-type: pds-github-util-built
 
 
 # -*- mode: yaml; indent: 4; fill-column: 120; coding: utf-8 -*-


### PR DESCRIPTION
**Summary**

Send a repository dispatch to github-actions-base after we build
pds-github-util so we can trigger a new build. This uses the Repository
Dispatch action https://github.com/marketplace/actions/repository-dispatch

Resolve #21

**Related Issues**
NASA-PDS/github-actions-base#10