### PR TITLE
Replace stable build with roundup-less build

### DIFF
--- a/.github/workflows/squaredown-stable.yaml
+++ b/.github/workflows/squaredown-stable.yaml
@@ -1,4 +1,4 @@
-# 🏃‍♀️ Continuous Integration and Delivery: Stable
+# 🏃‍♀️ Continuous Integration and Delivery: Squaredown Stable
 # ===============================================
 #
 # Note: for this workflow to succeed, the following secrets must be installed
@@ -19,16 +19,15 @@
 
 ---
 
-name: Roundup action free stable integration and delivery
+name:  Squaredown stable integration and delivery
 
 
 on:
-    release:
-        types: [published]
+    workflow_dispatch:
 
 jobs:
     stable-assembly:
-        name: 🐴 stable Assembly
+        name: 🟨 🔽 Stable Assembly
         runs-on: ubuntu-latest
         steps:
             -
@@ -49,7 +48,7 @@ jobs:
                     key: pds-${{runner.os}}-py-${{hashFiles('**/*.whl')}}
                     # To restore a set of files, we only need to match a prefix of the saved key.
                     restore-keys: pds-${{runner.os}}-py-
-            - 
+            -
                 name: Set up Python 3.9
                 uses: actions/setup-python@v1
                 with:
@@ -63,20 +62,18 @@ jobs:
                 run:
                     python setup.py bdist_wheel
             -
-                name: Publish package to TestPyPI
+                name: Publish package to PyPI
                 uses: pypa/gh-action-pypi-publish@release/v1
                 with:
                     # Should really use PyPI's API token stuff here
-                    user: ${{secrets.TEST_PYPI_USERNAME}}
-                    password: ${{secrets.TEST_PYPI_PASSWORD}}
-                    repository_url: https://test.pypi.org/legacy/
-
-            # -
-                # # Send a respository dispatch to pds-actions-base to trigger
-                # # a fresh build since it depends on pds-github-util
-                # name: Trigger github-actions-base build
-                # uses: peter-evans/repository-dispatch@v1
-                # with:
-                    # token: ${{secrets.ADMIN_GITHUB_TOKEN}}
-                    # repository: NASA-PDS/github-actions-base
-                    # event-type: pds-github-util-built
+                    user: ${{secrets.PYPI_USERNAME}}
+                    password: ${{secrets.PYPI_PASSWORD}}
+            -
+                 # Send a respository dispatch to pds-actions-base to trigger
+                 # a fresh build since it depends on pds-github-util
+                 name: Trigger github-actions-base build
+                 uses: peter-evans/repository-dispatch@v1
+                 with:
+                     token: ${{secrets.ADMIN_GITHUB_TOKEN}}
+                     repository: NASA-PDS/github-actions-base
+                     event-type: pds-github-util-built

--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -72,7 +72,6 @@ jobs:
                     pypi_username: ${{secrets.PYPI_USERNAME}}
                     pypi_password: ${{secrets.PYPI_PASSWORD}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
-
             -
                 # Send a respository dispatch to pds-actions-base to trigger
                 # a fresh build since it depends on pds-github-util


### PR DESCRIPTION
Add squaredown-stable for manually triggering a build and release to
PyPi to handle situations where our Roundup builds are broken due to
changes internal to pds-github-util.

Resolve #31

