### PR TITLE
Update SNAPSHOT handling in release utilities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PDS utility function for github
 
 Enforces the PDS engineering node software lifecycle:
-  - publish snapshot releases for python (`python-snapshot-release`) or maven  (`maven-snaphot-release`) projects
+  - publish snapshot releases for python (`python-release --snapshot`) or maven  (`maven-release --snapshot`) projects
   - create requirements reports (`requirement-report`)
   - ping a repository, ie creates an empty commit & push e.g. to trigger github action (`git-ping`)
   - create build summaries from .gitmodule file (`summaries`)
@@ -14,7 +14,7 @@ They are orchestrated around the [pdsen-corral](https://github.com/nasa-pds/pdse
 
 # Prerequisites
 
-libxml2 is used to do publish a snapshot release of a maven project (`maven-snaphot-release`). It needs to be deployed as follow:
+libxml2 is used to do publish a snapshot release of a maven project (`maven-release --snapshot`). It needs to be deployed as follow:
 
 ## Macos
 
@@ -43,8 +43,8 @@ Some environment variable need to be set (they are defined by default in github 
 
 Get command arguments for each of the available utilities using `--help` flag. e.g.
 
-    maven-snapshot-release --help
-    python-snapshot-release --help
+    maven-release --help
+    python-release --help
     requirement-report --help
     git-ping --help
     summaries --help

--- a/pds_github_util/release/python_release.py
+++ b/pds_github_util/release/python_release.py
@@ -11,7 +11,7 @@ from ._python_version import getVersion
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
-SNAPSHOT_TAG_SUFFIX = "-dev"
+SNAPSHOT_TAG_SUFFIX = "-SNAPSHOT"
 
 
 def python_get_version(workspace=None):

--- a/pds_github_util/release/release.py
+++ b/pds_github_util/release/release.py
@@ -76,7 +76,7 @@ def release_publication(suffix, get_version, upload_assets, prefix='v'):
     """
     Script made to work in the context of a github action.
     """
-    parser = argparse.ArgumentParser(description='Create new snapshot release')
+    parser = argparse.ArgumentParser(description='Create new release')
     addStandardArguments(parser)
     parser.add_argument('--token', dest='token',
                         help='github personal access token')
@@ -84,6 +84,7 @@ def release_publication(suffix, get_version, upload_assets, prefix='v'):
                         help='full name of github repo (e.g. user/repo)')
     parser.add_argument('--workspace',
                         help='path of workspace. defaults to current working directory if this or GITHUB_WORKSPACE not specified')
+    parser.add_argument('--snapshot', action="store_true", help="Mark release as a SNAPSHOT release.")
     args, unknown = parser.parse_known_args()
 
     # read organization and repository name
@@ -106,7 +107,6 @@ def release_publication(suffix, get_version, upload_assets, prefix='v'):
     repo_name = repo_full_name_array[1]
 
     tag_name = prefix + get_version(workspace)
-    print(tag_name)
     tagger = {"name": "PDSEN CI Bot",
               "email": "pdsen-ci@jpl.nasa.gov"}
 
@@ -114,7 +114,9 @@ def release_publication(suffix, get_version, upload_assets, prefix='v'):
     repo = gh.repository(org, repo_name)
 
     delete_snapshot_releases(repo, suffix)
-    if tag_name.endswith(suffix):
+    if tag_name.endswith(suffix) or args.snapshot:
+        if not tag_name.endswith(suffix):
+            tag_name = tag_name + suffix
         create_snapshot_release(repo, repo_name, "main", tag_name, tagger, upload_assets)
     else:
         create_release(repo, repo_name, "main", tag_name, tagger, upload_assets)

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,8 @@ setuptools.setup(
     entry_points={
         # snapshot-release for backward compatibility
         'console_scripts': ['snapshot-release=pds_github_util.release.maven_release:main',
-                            'maven-snapshot-release=pds_github_util.release.maven_release:main',
-                            'python-snapshot-release=pds_github_util.release.python_snapshot_release:main',
                             'maven-release=pds_github_util.release.maven_release:main',
-                            'python-release=pds_github_util.release.python_snapshot_release:main',
+                            'python-release=pds_github_util.release.python_release:main',
                             'requirement-report=pds_github_util.requirements.generate_requirements:main',
                             'git-ping=pds_github_util.branches.git_ping:main',
                             'summaries=pds_github_util.gh_pages.build_summaries:main',

--- a/tests/releases/test_python_get_version.py
+++ b/tests/releases/test_python_get_version.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import logging
-from pds_github_util.release.python_snapshot_release import python_get_version
+from pds_github_util.release.python_release import python_get_version
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Update release.release_publication to accept a `--snapshot` flag for
indicating when a published release should be marked as such. Logic has
been left in for determining if a release is a snapshot or not based on
tag prefix in case existing build processes rely on this.

Drop entry points for `maven-snapshot-release` and
`python-snapshot-release`. If you want a snapshot release you should
instead call `python-release --snapshot` or the maven equivalent.

Rename python_snapshot_release module to be inline with other support
modules. Update tests as necessary to accommodate.

Resolve #36

## Testing
Repo unit / functional tests are passing. Verified that the `*-release` scripts have the new flag but have not tested execution beyond that. Flying blind a little bit here.