### PR TITLE
Drop duplicate packaging dependency from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
         "github3.py>=1.3",
         "lxml>=4.5",
         "mdutils>=1.2",
-        "packaging>=20.4",
+        "packaging==20.9"
         "markdown2==2.3",
         "jinja2==3.0.1",
         "emoji==0.5",
@@ -44,7 +44,6 @@ setuptools.setup(
         "beautifulsoup4==4.9.0",
         "rstcloth==0.3.1",
         "pyyaml==5.4.1",
-        "packaging==20.9"
     ],
     entry_points={
         # snapshot-release for backward compatibility


### PR DESCRIPTION
Drop ranged `packaging` requirement (`>=20.4`) and keeping the specific
tagged version of `packaging==20.9`. A follow on ticket should determine
which is "correct". It looks as though the duplicate entry was added in
changes for #11 but I'm not sure it was necessarily intentional.

Resolve #41