### PR TITLE
Revert Python snapshot release naming for PEP 440 validity

### DIFF
--- a/pds_github_util/release/python_release.py
+++ b/pds_github_util/release/python_release.py
@@ -11,7 +11,7 @@ from ._python_version import getVersion
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
-SNAPSHOT_TAG_SUFFIX = "-SNAPSHOT"
+SNAPSHOT_TAG_SUFFIX = "-dev"
 
 
 def python_get_version(workspace=None):


### PR DESCRIPTION
Change Python snapshot release naming from using `-SNAPSHOT` as a
post-fix to `-dev` so we're generating valid PEP 440 version strings.

Resolve #44


