### PR TITLE
Add version pins to fix issues with clobbering dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import re
 import setuptools
 
 with open("README.md", "r") as fh:
@@ -31,19 +30,19 @@ setuptools.setup(
     ],
     python_requires='>=3.6',
     install_requires=[
-        "github3.py>=3.2.0",
-        "lxml>=4.5",
-        "mdutils>=1.2",
-        "packaging>=21.9",
-        "markdown2==2.4.3",
-        "jinja2==3.1.2",
-        "emoji==2.0.0",
-        "gitpython==3.1.27",
-        "requests==2.28.1",
-        "beautifulsoup4==4.9.0",
-        "rstcloth==0.4.0",
+        "github3.py==1.3.0",      # Do not change this version without also changing it in github-actions-base
+        "lxml==4.6.3",            # Do not change this version without also changing it in github-actions-base
+        "mdutils~=1.2.2",
+        "packaging==21.0",        # Do not change this version without also changing it in roundup-action
+        "markdown2~=2.4.3",
+        "jinja2<3.1",             # Do not change: Jinja2 ≥ 3.1 incompatible with Sphinx ≅ 3.2.1
+        "emoji~=2.0.0",
+        "gitpython~=3.1.27",
+        "requests==2.23.0",       # Do not change this version without also changing it in github-actions-base
+        "beautifulsoup4~=4.9.0",
+        "rstcloth~=0.4.0",
         "pyyaml==6.0",
-        "pyzenhub==0.3.1"
+        "pyzenhub~=0.3.1"
     ],
     entry_points={
         # snapshot-release for backward compatibility


### PR DESCRIPTION
## 🗒️ Summary

-   This sets some version pins and adds notes about them to make sure the `python-release` script works again
-   It also sets some version pins to ensure Sphinx works in our template-derived repositories
-   As a precautionary measure, it also sets some `~=` versions to avoid the [dependency confusion vulnerability](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

As an aside, it might be time to consider breaking up the monopoly that is `pds-github-util`. It's a package with a _lot_ of console scripts and we may start facing some inter-package conflicts just to keep all these console scripts running.

## ⚙️ Test Data and/or Report

See https://github.com/nasa-pds-engineering-node/sumo-tools/actions/runs/4056685843

## ♻️ Related Issues

- [roundup-action#105](https://github.com/NASA-PDS/pds-github-util/pull/new/roundup-action%23105)